### PR TITLE
Navbar implementation clean architecture

### DIFF
--- a/trooptrak_final_application/android/build.gradle
+++ b/trooptrak_final_application/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.22' // Use the latest stable version
+    ext.kotlin_version = '1.7.10' 
 
     repositories {
         google()
@@ -7,9 +7,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3' // Use the latest version
+        classpath 'com.android.tools.build:gradle:7.3.0' 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.15'  // Use the latest version
+        classpath 'com.google.gms:google-services:4.3.15'  
     }
 }
 

--- a/trooptrak_final_application/android/gradle/wrapper/gradle-wrapper.properties
+++ b/trooptrak_final_application/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Dec 24 16:56:15 SGT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/trooptrak_final_application/lib/core/providers/provider_setup.dart
+++ b/trooptrak_final_application/lib/core/providers/provider_setup.dart
@@ -26,6 +26,13 @@ import 'package:trooptrak_final_application/features/detailed_view/domain/usecas
 import 'package:trooptrak_final_application/features/nominal_roll/presentation/providers/user_provider.dart';
 import 'package:trooptrak_final_application/features/nominal_roll/presentation/providers/qr_scanner_provider.dart';
 import 'package:trooptrak_final_application/features/nominal_roll/presentation/providers/user_detail_provider.dart';
+import '../../features/conduct_tracker/presentation/providers/conduct_provider.dart';
+import '../../features/conduct_tracker/domain/usecases/get_conducts_usecase.dart';
+import '../../features/conduct_tracker/domain/usecases/add_conduct_usecase.dart';
+import '../../features/conduct_tracker/domain/usecases/update_conduct_usecase.dart';
+import '../../features/conduct_tracker/domain/usecases/delete_conduct_usecase.dart';
+import '../../features/conduct_tracker/data/repositories/conduct_repository_impl.dart';
+import '../../features/conduct_tracker/domain/usecases/get_conduct_by_id_usecase.dart';
 
 List<SingleChildWidget> getProviders() {
   return [
@@ -128,5 +135,24 @@ List<SingleChildWidget> getProviders() {
         deleteAttendance: DeleteAttendance(AttendanceRepositoryImpl(FirebaseFirestore.instance)),
       ),
     ),
+    ChangeNotifierProvider(
+    create: (context) => ConductProvider(
+      getConductsUseCase: GetConductsUseCase(
+        ConductRepositoryImpl(),
+      ),
+      addConductUseCase: AddConductUseCase(
+        ConductRepositoryImpl(),
+      ),
+      updateConductUseCase: UpdateConductUseCase(
+        ConductRepositoryImpl(),
+      ),
+      deleteConductUseCase: DeleteConductUseCase(
+        ConductRepositoryImpl(),
+      ),
+      getConductByIdUseCase: GetConductByIdUseCase(  // Add this
+      ConductRepositoryImpl(),
+    ),
+    ),
+  ),
   ];
 } 

--- a/trooptrak_final_application/lib/features/conduct_tracker/data/models/conduct_model.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/data/models/conduct_model.dart
@@ -1,0 +1,52 @@
+import 'package:trooptrak_final_application/features/conduct_tracker/domain/entities/conduct.dart';
+
+class ConductModel extends Conduct {
+  ConductModel({
+    required String id,
+    required String conductName,
+    required String conductType,
+    required String startDate,
+    required String startTime,
+    required String endTime,
+    required List<String> participants,
+    required List<String> nonParticipants,  // Add this
+    required Map<String, String> soldierReason,
+  }) : super(
+          id: id,
+          conductName: conductName,
+          conductType: conductType,
+          startDate: startDate,
+          startTime: startTime,
+          endTime: endTime,
+          participants: participants,
+          nonParticipants: nonParticipants,  // Add this
+          soldierReason: soldierReason,
+        );
+
+  factory ConductModel.fromJson(Map<String, dynamic> json, String id) {
+    return ConductModel(
+      id: id,
+      conductName: json['conductName'] as String,
+      conductType: json['conductType'] as String,
+      startDate: json['startDate'] as String,
+      startTime: json['startTime'] as String,
+      endTime: json['endTime'] as String,
+      participants: List<String>.from(json['participants'] as List),
+      nonParticipants: List<String>.from(json['nonParticipants'] as List? ?? []),  // Add this
+      soldierReason: Map<String, String>.from(json['soldierReason'] as Map),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'conductName': conductName,
+      'conductType': conductType,
+      'startDate': startDate,
+      'startTime': startTime,
+      'endTime': endTime,
+      'participants': participants,
+      'nonParticipants': nonParticipants,  // Add this
+      'soldierReason': soldierReason,
+    };
+  }
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/data/models/conduct_model.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/data/models/conduct_model.dart
@@ -2,26 +2,16 @@ import 'package:trooptrak_final_application/features/conduct_tracker/domain/enti
 
 class ConductModel extends Conduct {
   ConductModel({
-    required String id,
-    required String conductName,
-    required String conductType,
-    required String startDate,
-    required String startTime,
-    required String endTime,
-    required List<String> participants,
-    required List<String> nonParticipants,  // Add this
-    required Map<String, String> soldierReason,
-  }) : super(
-          id: id,
-          conductName: conductName,
-          conductType: conductType,
-          startDate: startDate,
-          startTime: startTime,
-          endTime: endTime,
-          participants: participants,
-          nonParticipants: nonParticipants,  // Add this
-          soldierReason: soldierReason,
-        );
+    required super.id,
+    required super.conductName,
+    required super.conductType,
+    required super.startDate,
+    required super.startTime,
+    required super.endTime,
+    required super.participants,
+    required super.nonParticipants,  // Add this
+    required super.soldierReason,
+  });
 
   factory ConductModel.fromJson(Map<String, dynamic> json, String id) {
     return ConductModel(

--- a/trooptrak_final_application/lib/features/conduct_tracker/data/repositories/conduct_repository_impl.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/data/repositories/conduct_repository_impl.dart
@@ -1,0 +1,70 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/entities/conduct.dart';
+import '../../domain/repositories/conduct_repository.dart';
+import '../models/conduct_model.dart';
+
+class ConductRepositoryImpl implements ConductRepository {
+  final FirebaseFirestore _firestore;
+
+  ConductRepositoryImpl({FirebaseFirestore? firestore}) 
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Stream<List<Conduct>> getConducts() {
+    return _firestore.collection('Conducts').snapshots().map((snapshot) {
+      return snapshot.docs.map((doc) {
+        return ConductModel.fromJson(doc.data(), doc.id);
+      }).toList();
+    });
+  }
+
+  @override
+  Future<void> addConduct(Conduct conduct) async {
+    final conductModel = ConductModel(
+      id: conduct.id,
+      conductName: conduct.conductName,
+      conductType: conduct.conductType,
+      startDate: conduct.startDate,
+      startTime: conduct.startTime,
+      endTime: conduct.endTime,
+      participants: conduct.participants,
+      nonParticipants: conduct.nonParticipants,
+      soldierReason: conduct.soldierReason,
+    );
+
+    await _firestore.collection('Conducts').add(conductModel.toJson());
+  }
+
+  @override
+  Future<void> updateConduct(Conduct conduct) async {
+    final conductModel = ConductModel(
+      id: conduct.id,
+      conductName: conduct.conductName,
+      conductType: conduct.conductType,
+      startDate: conduct.startDate,
+      startTime: conduct.startTime,
+      endTime: conduct.endTime,
+      participants: conduct.participants,
+      nonParticipants: conduct.nonParticipants,
+      soldierReason: conduct.soldierReason,
+    );
+
+    await _firestore
+        .collection('Conducts')
+        .doc(conduct.id)
+        .update(conductModel.toJson());
+  }
+
+  @override
+  Future<void> deleteConduct(String id) async {
+    await _firestore.collection('Conducts').doc(id).delete();
+  }
+
+  @override
+  Stream<Conduct> getConductById(String id) {
+    return _firestore.collection('Conducts').doc(id).snapshots().map((doc) {
+      if (!doc.exists) throw Exception('Conduct not found');
+      return ConductModel.fromJson(doc.data()!, doc.id);
+    });
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/entities/conduct.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/entities/conduct.dart
@@ -1,0 +1,23 @@
+class Conduct {
+  final String id;
+  final String conductName;
+  final String conductType;
+  final String startDate;
+  final String startTime;
+  final String endTime;
+  final List<String> participants;
+  final List<String> nonParticipants;  // Add this
+  final Map<String, String> soldierReason;
+
+  Conduct({
+    required this.id,
+    required this.conductName,
+    required this.conductType,
+    required this.startDate,
+    required this.startTime,
+    required this.endTime,
+    required this.participants,
+    required this.nonParticipants,  // Add this
+    required this.soldierReason,
+  });
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/repositories/conduct_repository.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/repositories/conduct_repository.dart
@@ -1,0 +1,9 @@
+import '../entities/conduct.dart';
+
+abstract class ConductRepository {
+  Stream<List<Conduct>> getConducts();
+  Future<void> addConduct(Conduct conduct);
+  Future<void> updateConduct(Conduct conduct);
+  Future<void> deleteConduct(String id);
+  Stream<Conduct> getConductById(String id);
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/add_conduct_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/add_conduct_usecase.dart
@@ -1,0 +1,12 @@
+import '../entities/conduct.dart';
+import '../repositories/conduct_repository.dart';
+
+class AddConductUseCase {
+  final ConductRepository repository;
+
+  AddConductUseCase(this.repository);
+
+  Future<void> call(Conduct conduct) {
+    return repository.addConduct(conduct);
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/delete_conduct_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/delete_conduct_usecase.dart
@@ -1,0 +1,11 @@
+import '../repositories/conduct_repository.dart';
+
+class DeleteConductUseCase {
+  final ConductRepository repository;
+
+  DeleteConductUseCase(this.repository);
+
+  Future<void> call(String id) {
+    return repository.deleteConduct(id);
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/filter_participants_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/filter_participants_usecase.dart
@@ -1,0 +1,76 @@
+class FilterParticipantsUseCase {
+  final Map<String, List<String>> conductTypeRestrictions = {
+    'run': ['Ex RMJ', 'Ex Lower Limb', 'LD'],
+    'route march': [
+      'Ex RMJ', 'Ex Heavy Loads', 'Ex Lower Limbs', 'LD',
+      'Ex Uniform', 'Ex Boots', 'Ex FLEGs',
+    ],
+    'ippt': [
+      'Ex Upper Limb', 'LD', 'Ex Lower Limb', 'Ex RMJ',
+      'Ex Pushup', 'Ex Situp'
+    ],
+    'outfield': [
+      'Ex Sunlight', 'Ex grass', 'Ex Outfield',
+      'Ex Uniform', 'Ex Boots'
+    ],
+    'metabolic circuit': [
+      'Ex RMJ', 'Ex Lower Limb', 'LD',
+    ],
+    'combat circuit': [
+      'Ex Uniform', 'Ex Boots', 'Ex RMJ', 'Ex Heavy Loads',
+      'Ex Lower Limb', 'Ex FLEGs', 'LD',
+    ],
+    'live firing': [
+      'Ex FLEGs', 'Ex Uniform', 'Ex Boots', 'LD',
+      'Ex Lower Limb', 'Ex RMJ'
+    ],
+    'soc/voc': [
+      'Ex Upper Limb', 'LD', 'Ex Lower Limb', 'Ex RMJ',
+      'Ex Uniform', 'Ex Boots', 'Ex FLEGs'
+    ],
+  };
+
+  Future<Map<String, String>> execute(
+    String conductType,
+    List<Map<String, dynamic>> statusList,
+  ) async {
+    Map<String, String> soldierReason = {};
+    
+    print('Filtering participants for conduct type: $conductType');
+    print('Received status list: $statusList');
+    
+    final normalizedConductType = conductType.toLowerCase();
+    
+    if (!conductTypeRestrictions.containsKey(normalizedConductType)) {
+      print('Warning: Unknown conduct type: $conductType (normalized: $normalizedConductType)');
+      print('Available conduct types: ${conductTypeRestrictions.keys.toList()}');
+      return soldierReason;
+    }
+
+    print('Restrictions for this conduct type: ${conductTypeRestrictions[normalizedConductType]}');
+
+    for (var status in statusList) {
+      print('Processing status: $status');
+      try {
+        if (status['statusType'] == 'Leave') {
+          soldierReason[status['Name']] = status['statusName'];
+          print('Soldier ${status['Name']} removed due to Leave: ${status['statusName']}');
+        } else if (status['statusType'] == 'Excuse') {
+          print('Checking excuse ${status['statusName']} against restrictions: ${conductTypeRestrictions[normalizedConductType]}');
+          if (conductTypeRestrictions[normalizedConductType]!.contains(status['statusName'])) {
+            soldierReason[status['Name']] = status['statusName'];
+            print('Soldier ${status['Name']} removed due to Excuse: ${status['statusName']}');
+          }
+        }
+      } catch (e) {
+        print('Error processing status for soldier: ${status['Name']}, Error: $e');
+        continue;
+      }
+    }
+
+    print('Total soldiers removed: ${soldierReason.length}');
+    print('Removal reasons: $soldierReason');
+    
+    return soldierReason;
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/get_conduct_by_id_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/get_conduct_by_id_usecase.dart
@@ -1,0 +1,12 @@
+import '../repositories/conduct_repository.dart';
+import '../entities/conduct.dart';
+
+class GetConductByIdUseCase {
+  final ConductRepository _repository;
+
+  GetConductByIdUseCase(this._repository);
+
+  Stream<Conduct> execute(String id) {
+    return _repository.getConductById(id);
+  }
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/get_conducts_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/get_conducts_usecase.dart
@@ -1,0 +1,12 @@
+import '../entities/conduct.dart';
+import '../repositories/conduct_repository.dart';
+
+class GetConductsUseCase {
+  final ConductRepository repository;
+
+  GetConductsUseCase(this.repository);
+
+  Stream<List<Conduct>> call() {
+    return repository.getConducts();
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/update_conduct_usecase.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/domain/usecases/update_conduct_usecase.dart
@@ -1,0 +1,12 @@
+import '../entities/conduct.dart';
+import '../repositories/conduct_repository.dart';
+
+class UpdateConductUseCase {
+  final ConductRepository repository;
+
+  UpdateConductUseCase(this.repository);
+
+  Future<void> call(Conduct conduct) {
+    return repository.updateConduct(conduct);
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
@@ -98,8 +98,16 @@ class _AddConductScreenState extends State<AddConductScreen> {
     });
   }
 
-  void _saveConduct() {
+  void _saveConduct() async {
     if (!_formKey.currentState!.validate()) return;
+
+    final allSoldiers = await context.read<ConductProvider>().getAllSoldierIds();
+    for (var soldier in allSoldiers) {
+      if (!_selectedParticipants.contains(soldier) && 
+          !_soldierReason.containsKey(soldier)) {
+        _soldierReason[soldier] = "Removed from conduct";
+      }
+    }
 
     final conduct = Conduct(
       id: widget.conduct?.id ?? '',
@@ -109,7 +117,9 @@ class _AddConductScreenState extends State<AddConductScreen> {
       startTime: _startTime,
       endTime: _endTime,
       participants: _selectedParticipants,
-      nonParticipants: _nonParticipants,
+      nonParticipants: allSoldiers
+          .where((id) => !_selectedParticipants.contains(id))
+          .toList(),
       soldierReason: _soldierReason,
     );
 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
@@ -8,7 +8,7 @@ import '../widgets/participant_selector.dart';
 class AddConductScreen extends StatefulWidget {
   final Conduct? conduct; // Optional - if provided, we're in edit mode
 
-  const AddConductScreen({Key? key, this.conduct}) : super(key: key);
+  const AddConductScreen({super.key, this.conduct});
 
   @override
   State<AddConductScreen> createState() => _AddConductScreenState();

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
@@ -23,6 +23,7 @@ class _AddConductScreenState extends State<AddConductScreen> {
   late String _endTime;
   List<String> _selectedParticipants = [];
   Map<String, String> _soldierReason = {};
+  List<String> _nonParticipants = [];
 
   final List<String> _conductTypes = [
     'Run',
@@ -85,6 +86,18 @@ class _AddConductScreenState extends State<AddConductScreen> {
     }
   }
 
+  void _onParticipantsChanged(List<String> participants, Map<String, String> reasons) async {
+    final allSoldiers = await context.read<ConductProvider>().getAllSoldierIds();
+    
+    setState(() {
+      _selectedParticipants = participants;
+      _soldierReason = reasons;
+      _nonParticipants = allSoldiers
+          .where((id) => !participants.contains(id))
+          .toList();
+    });
+  }
+
   void _saveConduct() {
     if (!_formKey.currentState!.validate()) return;
 
@@ -96,7 +109,8 @@ class _AddConductScreenState extends State<AddConductScreen> {
       startTime: _startTime,
       endTime: _endTime,
       participants: _selectedParticipants,
-      soldierReason: _soldierReason, nonParticipants: [],
+      nonParticipants: _nonParticipants,
+      soldierReason: _soldierReason,
     );
 
     if (widget.conduct != null) {
@@ -171,10 +185,11 @@ class _AddConductScreenState extends State<AddConductScreen> {
                 selectedParticipants: _selectedParticipants,
                 soldierReason: _soldierReason,
                 conductType: _selectedConductType,
-                onParticipantsChanged: (participants, reasons) {
+                onParticipantsChanged: (participants, reasons, nonParticipants) {
                   setState(() {
                     _selectedParticipants = participants;
                     _soldierReason = reasons;
+                    _nonParticipants = nonParticipants;
                   });
                 },
               ),

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/add_conduct_screen.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../../domain/entities/conduct.dart';
+import '../providers/conduct_provider.dart';
+import '../widgets/participant_selector.dart';
+
+class AddConductScreen extends StatefulWidget {
+  final Conduct? conduct; // Optional - if provided, we're in edit mode
+
+  const AddConductScreen({Key? key, this.conduct}) : super(key: key);
+
+  @override
+  State<AddConductScreen> createState() => _AddConductScreenState();
+}
+
+class _AddConductScreenState extends State<AddConductScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _conductNameController;
+  String? _selectedConductType;
+  late String _startDate;
+  late String _startTime;
+  late String _endTime;
+  List<String> _selectedParticipants = [];
+  Map<String, String> _soldierReason = {};
+
+  final List<String> _conductTypes = [
+    'Run',
+    'S&P',
+    'IMT',
+    'ATP',
+    'IPPT',
+    'SOC',
+    'Metabolic Circuit',
+    'Combat Circuit',
+    'Route March',
+    'Outfield',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _conductNameController = TextEditingController(text: widget.conduct?.conductName);
+    _selectedConductType = widget.conduct?.conductType;
+    _startDate = widget.conduct?.startDate ?? DateFormat('d MMM yyyy').format(DateTime.now());
+    _startTime = widget.conduct?.startTime ?? 'Start Time:';
+    _endTime = widget.conduct?.endTime ?? 'End Time:';
+    _selectedParticipants = widget.conduct?.participants ?? [];
+    _soldierReason = widget.conduct?.soldierReason ?? {};
+  }
+
+  @override
+  void dispose() {
+    _conductNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectDate(BuildContext context) async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: DateFormat('d MMM yyyy').parse(_startDate),
+      firstDate: DateTime(2022),
+      lastDate: DateTime(2025),
+    );
+    if (picked != null) {
+      setState(() {
+        _startDate = DateFormat('d MMM yyyy').format(picked);
+      });
+    }
+  }
+
+  Future<void> _selectTime(BuildContext context, bool isStartTime) async {
+    final TimeOfDay? picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (picked != null) {
+      setState(() {
+        if (isStartTime) {
+          _startTime = picked.format(context);
+        } else {
+          _endTime = picked.format(context);
+        }
+      });
+    }
+  }
+
+  void _saveConduct() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final conduct = Conduct(
+      id: widget.conduct?.id ?? '',
+      conductName: _conductNameController.text,
+      conductType: _selectedConductType!,
+      startDate: _startDate,
+      startTime: _startTime,
+      endTime: _endTime,
+      participants: _selectedParticipants,
+      soldierReason: _soldierReason, nonParticipants: [],
+    );
+
+    if (widget.conduct != null) {
+      context.read<ConductProvider>().updateConduct(conduct);
+    } else {
+      context.read<ConductProvider>().addConduct(conduct);
+    }
+
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.conduct != null ? 'Edit Conduct' : 'Add New Conduct'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _conductNameController,
+                decoration: const InputDecoration(labelText: 'Conduct Name'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a conduct name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: _selectedConductType,
+                decoration: const InputDecoration(labelText: 'Conduct Type'),
+                items: _conductTypes.map((type) {
+                  return DropdownMenuItem(value: type, child: Text(type));
+                }).toList(),
+                onChanged: (value) {
+                  setState(() {
+                    _selectedConductType = value;
+                  });
+                },
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please select a conduct type';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              ListTile(
+                title: Text(_startDate),
+                trailing: const Icon(Icons.calendar_today),
+                onTap: () => _selectDate(context),
+              ),
+              ListTile(
+                title: Text(_startTime),
+                trailing: const Icon(Icons.access_time),
+                onTap: () => _selectTime(context, true),
+              ),
+              ListTile(
+                title: Text(_endTime),
+                trailing: const Icon(Icons.access_time),
+                onTap: () => _selectTime(context, false),
+              ),
+              const SizedBox(height: 16),
+              ParticipantSelector(
+                selectedParticipants: _selectedParticipants,
+                soldierReason: _soldierReason,
+                conductType: _selectedConductType,
+                onParticipantsChanged: (participants, reasons) {
+                  setState(() {
+                    _selectedParticipants = participants;
+                    _soldierReason = reasons;
+                  });
+                },
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _saveConduct,
+                  child: Text(widget.conduct != null ? 'Update Conduct' : 'Add Conduct'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_details_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_details_screen.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../domain/entities/conduct.dart';
+import '../providers/conduct_provider.dart';
+import 'add_conduct_screen.dart';
+
+class ConductDetailsScreen extends StatelessWidget {
+  final String conductId;
+
+  const ConductDetailsScreen({
+    super.key,
+    required this.conductId,
+  });
+
+  void _showDeleteDialog(BuildContext context, String conductId) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Conduct'),
+        content: const Text('Are you sure you want to delete this conduct?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              context.read<ConductProvider>().deleteConduct(conductId);
+              Navigator.pop(context); // Close dialog
+              Navigator.pop(context); // Go back to previous screen
+            },
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoSection(BuildContext context, {required String title, required List<Widget> children}) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Text(
+            '$label: ',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          Text(value),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildParticipantsSection(BuildContext context, Conduct conductData) {
+    return _buildInfoSection(
+      context,
+      title: 'Participants',
+      children: [
+        if (conductData.participants.isEmpty)
+          const Text('No participants')
+        else
+          ...conductData.participants.map((participant) => Text(participant)),
+      ],
+    );
+  }
+
+  Widget _buildNonParticipantsSection(BuildContext context, Conduct conductData) {
+    return _buildInfoSection(
+      context,
+      title: 'Non-Participants',
+      children: [
+        if (conductData.nonParticipants.isEmpty)
+          const Text('No non-participants')
+        else
+          ...conductData.nonParticipants.map((nonParticipant) => Text(nonParticipant)),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Conduct>(
+      stream: context.read<ConductProvider>().getConductById(conductId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (!snapshot.hasData) {
+          return const Scaffold(
+            body: Center(child: Text('Conduct not found')),
+          );
+        }
+
+        final conductData = snapshot.data!;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Conduct Details'),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.edit),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => AddConductScreen(conduct: conductData),
+                    ),
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () => _showDeleteDialog(context, conductData.id),
+              ),
+            ],
+          ),
+          body: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildInfoSection(
+                  context,
+                  title: 'Conduct Information',
+                  children: [
+                    _buildInfoRow('Name', conductData.conductName),
+                    _buildInfoRow('Type', conductData.conductType),
+                    _buildInfoRow('Date', conductData.startDate),
+                    _buildInfoRow('Time', '${conductData.startTime} - ${conductData.endTime}'),
+                  ],
+                ),
+                _buildParticipantsSection(context, conductData),
+                _buildNonParticipantsSection(context, conductData),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_details_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_details_screen.dart
@@ -89,7 +89,30 @@ class ConductDetailsScreen extends StatelessWidget {
         if (conductData.nonParticipants.isEmpty)
           const Text('No non-participants')
         else
-          ...conductData.nonParticipants.map((nonParticipant) => Text(nonParticipant)),
+          ...conductData.nonParticipants.map((nonParticipant) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        nonParticipant,
+                        style: const TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Reason: ${conductData.soldierReason[nonParticipant] ?? 'No reason provided'}',
+                        style: TextStyle(
+                          color: Colors.grey[600],
+                          fontStyle: FontStyle.italic,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
       ],
     );
   }

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_tracker_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_tracker_screen.dart
@@ -10,7 +10,7 @@ import '../widgets/no_conducts_widget.dart';
 import '../../domain/entities/conduct.dart';
 
 class ConductTrackerScreen extends StatelessWidget {
-  const ConductTrackerScreen({Key? key}) : super(key: key);
+  const ConductTrackerScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -21,12 +21,12 @@ class ConductTrackerScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Padding(
+              const Padding(
                 padding: EdgeInsets.all(20.0),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const DateSelector(),
+                    DateSelector(),
                     AddConductButton(),
                   ],
                 ),

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_tracker_screen.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/pages/conduct_tracker_screen.dart
@@ -1,12 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/conduct_provider.dart';
+import '../widgets/conduct_calendar.dart';
+import '../widgets/conduct_bar_graph.dart';
+import '../widgets/conduct_list.dart';
+import '../widgets/date_selector.dart';
+import '../widgets/add_conduct_button.dart';
+import '../widgets/no_conducts_widget.dart';
+import '../../domain/entities/conduct.dart';
 
 class ConductTrackerScreen extends StatelessWidget {
-  const ConductTrackerScreen({super.key});
+  const ConductTrackerScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Conduct Tracker - Coming Soon'),
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: EdgeInsets.all(20.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const DateSelector(),
+                    AddConductButton(),
+                  ],
+                ),
+              ),
+              const ConductCalendar(),
+              const SizedBox(height: 30),
+              StreamBuilder<List<Conduct>>(
+                stream: context.watch<ConductProvider>().conducts,
+                builder: (context, snapshot) {
+                  if (snapshot.hasError) {
+                    return Center(child: Text('Error: ${snapshot.error}'));
+                  }
+
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  final conducts = snapshot.data!;
+                  final selectedDate = context.watch<ConductProvider>().selectedDate;
+                  final todayConducts = context.read<ConductProvider>()
+                      .filterConductsByDate(conducts, selectedDate);
+
+                  if (todayConducts.isEmpty) {
+                    return const NoConductsWidget();
+                  }
+
+                  return Column(
+                    children: [
+                      ConductBarGraph(
+                        conducts: todayConducts,
+                        participationStrength: context
+                            .read<ConductProvider>()
+                            .getParticipationStrength(todayConducts),
+                      ),
+                      const SizedBox(height: 20),
+                      ConductList(conducts: todayConducts),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
-}
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/entities/conduct.dart';
 import '../../domain/usecases/add_conduct_usecase.dart';
 import '../../domain/usecases/delete_conduct_usecase.dart';
@@ -37,13 +38,59 @@ class ConductProvider extends ChangeNotifier {
   }
 
   Future<void> addConduct(Conduct conduct) async {
-    await _addConductUseCase(conduct);
-    notifyListeners();
+    try {
+      final allSoldiers = await getAllSoldierIds();
+      
+      final nonParticipants = allSoldiers
+          .where((id) => !conduct.participants.contains(id))
+          .toList();
+
+      final updatedConduct = Conduct(
+        id: conduct.id,
+        conductName: conduct.conductName,
+        conductType: conduct.conductType,
+        startDate: conduct.startDate,
+        startTime: conduct.startTime,
+        endTime: conduct.endTime,
+        participants: conduct.participants,
+        nonParticipants: nonParticipants,
+        soldierReason: conduct.soldierReason,
+      );
+
+      await _addConductUseCase(updatedConduct);
+      notifyListeners();
+    } catch (e) {
+      print('Error in addConduct: $e');
+      rethrow;
+    }
   }
 
   Future<void> updateConduct(Conduct conduct) async {
-    await _updateConductUseCase(conduct);
-    notifyListeners();
+    try {
+      final allSoldiers = await getAllSoldierIds();
+      
+      final nonParticipants = allSoldiers
+          .where((id) => !conduct.participants.contains(id))
+          .toList();
+
+      final updatedConduct = Conduct(
+        id: conduct.id,
+        conductName: conduct.conductName,
+        conductType: conduct.conductType,
+        startDate: conduct.startDate,
+        startTime: conduct.startTime,
+        endTime: conduct.endTime,
+        participants: conduct.participants,
+        nonParticipants: nonParticipants,
+        soldierReason: conduct.soldierReason,
+      );
+
+      await _updateConductUseCase(updatedConduct);
+      notifyListeners();
+    } catch (e) {
+      print('Error in updateConduct: $e');
+      rethrow;
+    }
   }
 
   Future<void> deleteConduct(String id) async {
@@ -66,5 +113,10 @@ class ConductProvider extends ChangeNotifier {
 
   List<double> getParticipationStrength(List<Conduct> conducts) {
     return conducts.map((conduct) => conduct.participants.length.toDouble()).toList();
+  }
+
+  Future<List<String>> getAllSoldierIds() async {
+    final snapshot = await FirebaseFirestore.instance.collection('Users').get();
+    return snapshot.docs.map((doc) => doc.id).toList();
   }
 }

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
@@ -119,4 +119,57 @@ class ConductProvider extends ChangeNotifier {
     final snapshot = await FirebaseFirestore.instance.collection('Users').get();
     return snapshot.docs.map((doc) => doc.id).toList();
   }
+
+  Future<List<Map<String, dynamic>>> getSoldiersStatus() async {
+    List<Map<String, dynamic>> statusList = [];
+
+    try {
+      print('Fetching soldiers status...');
+      final querySnapshot = await FirebaseFirestore.instance
+          .collection("Users")
+          .get();
+      
+      print('Found ${querySnapshot.docs.length} users');
+
+      for (var snapshot in querySnapshot.docs) {
+        final statusSnapshot = await FirebaseFirestore.instance
+            .collection("Users")
+            .doc(snapshot.id)
+            .collection("Statuses")
+            .get();
+
+        print('Found ${statusSnapshot.docs.length} statuses for user ${snapshot.id}');
+
+        for (var result in statusSnapshot.docs) {
+          Map<String, dynamic> data = result.data();
+          print('Status data for ${snapshot.id}: $data');
+          
+          if (data['end_id'] != null) {
+            try {
+              DateTime end = DateTime.parse(data['end_id'].toString());
+              if (end.isAfter(DateTime.now())) {
+                data['Name'] = snapshot.id;
+                statusList.add({
+                  'Name': snapshot.id,
+                  'statusType': data['statusType'],
+                  'statusName': data['statusName'],
+                  'endDate': end.toString(),
+                });
+                print('Added status for ${snapshot.id}: ${data['statusType']} - ${data['statusName']}');
+              }
+            } catch (e) {
+              print('Error parsing date for soldier ${snapshot.id}: ${e.toString()}');
+              continue;
+            }
+          }
+        }
+      }
+
+      print('Final status list: $statusList');
+      return statusList;
+    } catch (e) {
+      print('Error getting soldiers status: ${e.toString()}');
+      return [];
+    }
+  }
 }

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/providers/conduct_provider.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../domain/entities/conduct.dart';
+import '../../domain/usecases/add_conduct_usecase.dart';
+import '../../domain/usecases/delete_conduct_usecase.dart';
+import '../../domain/usecases/get_conducts_usecase.dart';
+import '../../domain/usecases/update_conduct_usecase.dart';
+import '../../domain/usecases/get_conduct_by_id_usecase.dart';
+
+class ConductProvider extends ChangeNotifier {
+  final GetConductsUseCase _getConductsUseCase;
+  final AddConductUseCase _addConductUseCase;
+  final UpdateConductUseCase _updateConductUseCase;
+  final DeleteConductUseCase _deleteConductUseCase;
+  final GetConductByIdUseCase _getConductByIdUseCase;
+
+  ConductProvider({
+    required GetConductsUseCase getConductsUseCase,
+    required AddConductUseCase addConductUseCase,
+    required UpdateConductUseCase updateConductUseCase,
+    required DeleteConductUseCase deleteConductUseCase,
+    required GetConductByIdUseCase getConductByIdUseCase,
+  })  : _getConductsUseCase = getConductsUseCase,
+        _addConductUseCase = addConductUseCase,
+        _updateConductUseCase = updateConductUseCase,
+        _deleteConductUseCase = deleteConductUseCase,
+        _getConductByIdUseCase = getConductByIdUseCase;
+
+  Stream<List<Conduct>> get conducts => _getConductsUseCase();
+
+  DateTime _selectedDate = DateTime.now();
+  DateTime get selectedDate => _selectedDate;
+
+  void updateSelectedDate(DateTime date) {
+    _selectedDate = date;
+    notifyListeners();
+  }
+
+  Future<void> addConduct(Conduct conduct) async {
+    await _addConductUseCase(conduct);
+    notifyListeners();
+  }
+
+  Future<void> updateConduct(Conduct conduct) async {
+    await _updateConductUseCase(conduct);
+    notifyListeners();
+  }
+
+  Future<void> deleteConduct(String id) async {
+    await _deleteConductUseCase(id);
+    notifyListeners();
+  }
+
+  Stream<Conduct> getConductById(String id) {
+    return _getConductByIdUseCase.execute(id);
+  }
+
+  List<Conduct> filterConductsByDate(List<Conduct> conducts, DateTime date) {
+    return conducts.where((conduct) {
+      final conductDate = DateFormat('d MMM yyyy').parse(conduct.startDate);
+      return conductDate.year == date.year &&
+          conductDate.month == date.month &&
+          conductDate.day == date.day;
+    }).toList();
+  }
+
+  List<double> getParticipationStrength(List<Conduct> conducts) {
+    return conducts.map((conduct) => conduct.participants.length.toDouble()).toList();
+  }
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/add_conduct_button.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/add_conduct_button.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import '../pages/add_conduct_screen.dart';
+
+class AddConductButton extends StatelessWidget {
+  const AddConductButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const AddConductScreen(),
+          ),
+        );
+      },
+      child: const Icon(Icons.add),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_bar_graph.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_bar_graph.dart
@@ -1,7 +1,8 @@
-import 'dart:math';
-
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:google_fonts/google_fonts.dart';
 import '../../domain/entities/conduct.dart';
 
 class ConductBarGraph extends StatelessWidget {
@@ -14,51 +15,87 @@ class ConductBarGraph extends StatelessWidget {
     required this.participationStrength,
   });
 
+  double _calculateMaxY() {
+    if (participationStrength.isEmpty) return 5.0; // Default max when no data
+    double maxParticipants = participationStrength.reduce((a, b) => a > b ? a : b);
+    // Add 2 to the max value to ensure bars don't reach the top
+    return maxParticipants + 2.0;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 200, // Reduced height
-      padding: const EdgeInsets.all(16.0),
-      child: BarChart(
-        BarChartData(
-          alignment: BarChartAlignment.spaceEvenly,
-          maxY: participationStrength.isEmpty ? 1 : participationStrength.reduce(max),
-          minY: 0,
-          gridData: const FlGridData(show: false),
-          borderData: FlBorderData(
-            show: true,
-            border: Border.all(color: Theme.of(context).colorScheme.tertiary),
-          ),
-          titlesData: FlTitlesData(
-            show: true,
-            bottomTitles: AxisTitles(
-              sideTitles: SideTitles(
-                showTitles: true,
-                getTitlesWidget: (value, meta) => _buildTitle(value, context),
-                reservedSize: 40,
+    return AspectRatio(
+      aspectRatio: 1,
+      child: Container(
+        padding: EdgeInsets.all(16.0.sp),
+        child: BarChart(
+          BarChartData(
+            alignment: BarChartAlignment.spaceEvenly,
+            maxY: _calculateMaxY(),
+            minY: 0,
+            gridData: const FlGridData(show: false),
+            borderData: FlBorderData(
+              show: true,
+              border: Border.all(color: Theme.of(context).colorScheme.tertiary),
+            ),
+            barTouchData: BarTouchData(
+              enabled: false,
+              touchTooltipData: BarTouchTooltipData(
+                fitInsideHorizontally: true,
+                fitInsideVertically: true,
+                direction: TooltipDirection.top,
+                tooltipMargin: 4,
+                getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                  return BarTooltipItem(
+                    rod.toY.round().toString(),
+                    GoogleFonts.poppins(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.sp,
+                    ),
+                  );
+                },
               ),
             ),
-            topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-            leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-            rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            titlesData: FlTitlesData(
+              show: true,
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, meta) => _buildTitle(value, meta, context),
+                  reservedSize: 30.sp,
+                ),
+              ),
+              topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            ),
+            barGroups: _createBarGroups(),
           ),
-          barGroups: _createBarGroups(),
         ),
       ),
     );
   }
 
-  Widget _buildTitle(double value, BuildContext context) {
+  Widget _buildTitle(double value, TitleMeta meta, BuildContext context) {
     if (value.toInt() >= conducts.length) return const SizedBox.shrink();
     
     return SideTitleWidget(
-      axisSide: AxisSide.bottom,
+      axisSide: meta.axisSide,
       space: 2,
-      child: Text(
-        conducts[value.toInt()].conductName,
-        style: Theme.of(context).textTheme.bodySmall,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      fitInside: const SideTitleFitInsideData(
+        enabled: true,
+        axisPosition: 20,
+        parentAxisSize: 50,
+        distanceFromEdge: -10,
+      ),
+      child: SizedBox(
+        child: AutoSizeText(
+          conducts[value.toInt()].conductName,
+          style: GoogleFonts.poppins(fontWeight: FontWeight.w500),
+          maxLines: 1,
+          wrapWords: false,
+          overflow: TextOverflow.clip,
+        ),
       ),
     );
   }
@@ -79,8 +116,8 @@ class ConductBarGraph extends StatelessWidget {
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
             ),
-            width: 200 * (1 / participationStrength.length),
-            borderRadius: BorderRadius.circular(4),
+            width: (200 * (1 / participationStrength.length)).w,
+            borderRadius: BorderRadius.circular(4.r),
           ),
         ],
         showingTooltipIndicators: [0],

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_bar_graph.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_bar_graph.dart
@@ -1,0 +1,90 @@
+import 'dart:math';
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import '../../domain/entities/conduct.dart';
+
+class ConductBarGraph extends StatelessWidget {
+  final List<Conduct> conducts;
+  final List<double> participationStrength;
+
+  const ConductBarGraph({
+    super.key,
+    required this.conducts,
+    required this.participationStrength,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 200, // Reduced height
+      padding: const EdgeInsets.all(16.0),
+      child: BarChart(
+        BarChartData(
+          alignment: BarChartAlignment.spaceEvenly,
+          maxY: participationStrength.isEmpty ? 1 : participationStrength.reduce(max),
+          minY: 0,
+          gridData: const FlGridData(show: false),
+          borderData: FlBorderData(
+            show: true,
+            border: Border.all(color: Theme.of(context).colorScheme.tertiary),
+          ),
+          titlesData: FlTitlesData(
+            show: true,
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) => _buildTitle(value, context),
+                reservedSize: 40,
+              ),
+            ),
+            topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          ),
+          barGroups: _createBarGroups(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitle(double value, BuildContext context) {
+    if (value.toInt() >= conducts.length) return const SizedBox.shrink();
+    
+    return SideTitleWidget(
+      axisSide: AxisSide.bottom,
+      space: 2,
+      child: Text(
+        conducts[value.toInt()].conductName,
+        style: Theme.of(context).textTheme.bodySmall,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  List<BarChartGroupData> _createBarGroups() {
+    return List.generate(
+      conducts.length,
+      (index) => BarChartGroupData(
+        x: index,
+        barRods: [
+          BarChartRodData(
+            toY: participationStrength[index],
+            gradient: const LinearGradient(
+              colors: [
+                Color.fromARGB(255, 72, 30, 229),
+                Color.fromARGB(255, 130, 60, 229),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            width: 200 * (1 / participationStrength.length),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ],
+        showingTooltipIndicators: [0],
+      ),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_calendar.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_calendar.dart
@@ -11,7 +11,7 @@ class ConductCalendar extends StatelessWidget {
     final selectedDate = context.watch<ConductProvider>().selectedDate;
     final currentDate = DateTime.now();
     
-    return Container(
+    return SizedBox(
       height: 110,
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -26,7 +26,7 @@ class ConductCalendar extends StatelessWidget {
             },
             child: Container(
               width: 80,
-              margin: EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+              margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
               decoration: BoxDecoration(
                 color: isSelected 
                     ? Theme.of(context).colorScheme.primary

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_calendar.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_calendar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/conduct_provider.dart';
+import 'package:intl/intl.dart';
+
+class ConductCalendar extends StatelessWidget {
+  const ConductCalendar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedDate = context.watch<ConductProvider>().selectedDate;
+    final currentDate = DateTime.now();
+    
+    return Container(
+      height: 110,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: 14, // Show 2 weeks of dates
+        itemBuilder: (context, index) {
+          final date = currentDate.subtract(Duration(days: 7 - index));
+          final isSelected = _isSameDay(date, selectedDate);
+          
+          return GestureDetector(
+            onTap: () {
+              context.read<ConductProvider>().updateSelectedDate(date);
+            },
+            child: Container(
+              width: 80,
+              margin: EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected 
+                    ? Theme.of(context).colorScheme.primary
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: isSelected 
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.outline,
+                ),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    DateFormat('EEE').format(date),
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: isSelected 
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    DateFormat('d').format(date),
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: isSelected 
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    DateFormat('MMM').format(date),
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: isSelected 
+                          ? Colors.white
+                          : Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  bool _isSameDay(DateTime date1, DateTime date2) {
+    return date1.year == date2.year &&
+           date1.month == date2.month &&
+           date1.day == date2.day;
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_list.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_list.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/conduct.dart';
+import 'conduct_tile.dart';
+import '../pages/conduct_details_screen.dart';
+
+class ConductList extends StatelessWidget {
+  final List<Conduct> conducts;
+
+  const ConductList({
+    super.key,
+    required this.conducts,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: conducts.length,
+      itemBuilder: (context, index) {
+        final conduct = conducts[index];
+        return InkWell(
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => ConductDetailsScreen(conductId: conduct.id),
+              ),
+            );
+          },
+          child: ConductTile(
+            conductNumber: index,
+            conductName: conduct.conductName,
+            conductType: conduct.conductType,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_tile.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_tile.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class ConductTile extends StatelessWidget {
+  final String conductType;
+  final String conductName;
+  final int conductNumber;
+
+  const ConductTile({
+    Key? key,
+    required this.conductName,
+    required this.conductType,
+    required this.conductNumber,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      color: Colors.transparent,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(right: 30.0),
+            child: Container(
+              height: 70,
+              width: 70,
+              decoration: BoxDecoration(
+                color: const Color.fromARGB(255, 53, 14, 145),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Center(
+                child: Text(
+                  (conductNumber + 1).toString(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 24,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  conductType,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                Text(
+                  conductName,
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Icon(Icons.arrow_forward_outlined),
+        ],
+      ),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_tile.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/conduct_tile.dart
@@ -6,11 +6,11 @@ class ConductTile extends StatelessWidget {
   final int conductNumber;
 
   const ConductTile({
-    Key? key,
+    super.key,
     required this.conductName,
     required this.conductType,
     required this.conductNumber,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/date_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/date_selector.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/conduct_provider.dart';
+
+class DateSelector extends StatelessWidget {
+  const DateSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () async {
+        final DateTime? picked = await showDatePicker(
+          context: context,
+          initialDate: context.read<ConductProvider>().selectedDate,
+          firstDate: DateTime(2022),
+          lastDate: DateTime(2025),
+        );
+        if (picked != null) {
+          context.read<ConductProvider>().updateSelectedDate(picked);
+        }
+      },
+      child: const Text('Select Date'),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/no_conducts_widget.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/no_conducts_widget.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class NoConductsWidget extends StatelessWidget {
+  const NoConductsWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(16.0),
+        child: Text(
+          'No conducts scheduled for this date',
+          style: TextStyle(fontSize: 16),
+        ),
+      ),
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -22,6 +22,7 @@ class ParticipantSelector extends StatefulWidget {
 class _ParticipantSelectorState extends State<ParticipantSelector> {
   List<Map<String, dynamic>> _allSoldiers = [];
   String _searchQuery = '';
+  bool _isInitialized = false;
 
   @override
   void initState() {
@@ -31,11 +32,21 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
 
   Future<void> _loadSoldiers() async {
     final snapshot = await FirebaseFirestore.instance.collection('Users').get();
+    final soldiers = snapshot.docs
+        .map((doc) => {...doc.data(), 'id': doc.id})
+        .toList();
+    
     setState(() {
-      _allSoldiers = snapshot.docs
-          .map((doc) => {...doc.data(), 'id': doc.id})
-          .toList();
+      _allSoldiers = soldiers;
     });
+
+    // Auto-select all participants only when the screen is first loaded
+    // and no participants are already selected
+    if (!_isInitialized && widget.selectedParticipants.isEmpty) {
+      final List<String> allSoldierIds = soldiers.map((s) => s['id'].toString()).toList();
+      widget.onParticipantsChanged(allSoldierIds, {});
+      _isInitialized = true;
+    }
   }
 
   List<Map<String, dynamic>> get _filteredSoldiers {
@@ -77,12 +88,34 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
           },
         ),
         const SizedBox(height: 16),
-        const Text(
-          'Select Participants',
-          style: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.bold,
-          ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              'Select Participants',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            TextButton(
+              onPressed: () {
+                if (widget.selectedParticipants.length == _allSoldiers.length) {
+                  // Deselect all
+                  widget.onParticipantsChanged([], {});
+                } else {
+                  // Select all
+                  final allSoldierIds = _allSoldiers.map((s) => s['id'].toString()).toList();
+                  widget.onParticipantsChanged(allSoldierIds, {});
+                }
+              },
+              child: Text(
+                widget.selectedParticipants.length == _allSoldiers.length
+                    ? 'Deselect All'
+                    : 'Select All',
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 8),
         ListView.builder(

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:provider/provider.dart';
+import '../../domain/usecases/filter_participants_usecase.dart';
+import '../providers/conduct_provider.dart';
 
 class ParticipantSelector extends StatefulWidget {
   final List<String> selectedParticipants;
@@ -8,18 +11,54 @@ class ParticipantSelector extends StatefulWidget {
   final Function(List<String>, Map<String, String>, List<String>) onParticipantsChanged;
 
   const ParticipantSelector({
-    super.key,
+    Key? key,
     required this.selectedParticipants,
     required this.soldierReason,
     required this.conductType,
     required this.onParticipantsChanged,
-  });
+  }) : super(key: key);
 
   @override
   State<ParticipantSelector> createState() => _ParticipantSelectorState();
 }
 
 class _ParticipantSelectorState extends State<ParticipantSelector> {
+  late List<String> _selectedParticipants;
+  late Map<String, String> _soldierReason;
+  bool _isInitialized = false;
+
+  @override
+  void didUpdateWidget(ParticipantSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.conductType != oldWidget.conductType) {
+      _applyAutomaticFiltering();
+    }
+  }
+
+  Future<void> _applyAutomaticFiltering() async {
+    if (widget.conductType == null) return;
+
+    final provider = context.read<ConductProvider>();
+    final allSoldiers = await provider.getAllSoldierIds();
+    final statusList = await provider.getSoldiersStatus();
+    
+    final filterUseCase = FilterParticipantsUseCase();
+    final soldierReason = await filterUseCase.execute(widget.conductType!, statusList);
+
+    setState(() {
+      _selectedParticipants = allSoldiers
+          .where((id) => !soldierReason.containsKey(id))
+          .toList();
+      _soldierReason = soldierReason;
+    });
+
+    widget.onParticipantsChanged(
+      _selectedParticipants,
+      _soldierReason,
+      allSoldiers.where((id) => soldierReason.containsKey(id)).toList(),
+    );
+  }
+
   List<Map<String, dynamic>> _allSoldiers = [];
   String _searchQuery = '';
   List<String> _nonParticipants = [];

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ParticipantSelector extends StatefulWidget {
+  final List<String> selectedParticipants;
+  final Map<String, String> soldierReason;
+  final String? conductType;
+  final Function(List<String>, Map<String, String>) onParticipantsChanged;
+
+  const ParticipantSelector({
+    Key? key,
+    required this.selectedParticipants,
+    required this.soldierReason,
+    required this.conductType,
+    required this.onParticipantsChanged,
+  }) : super(key: key);
+
+  @override
+  State<ParticipantSelector> createState() => _ParticipantSelectorState();
+}
+
+class _ParticipantSelectorState extends State<ParticipantSelector> {
+  List<Map<String, dynamic>> _allSoldiers = [];
+  String _searchQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSoldiers();
+  }
+
+  Future<void> _loadSoldiers() async {
+    final snapshot = await FirebaseFirestore.instance.collection('Users').get();
+    setState(() {
+      _allSoldiers = snapshot.docs
+          .map((doc) => {...doc.data(), 'id': doc.id})
+          .toList();
+    });
+  }
+
+  List<Map<String, dynamic>> get _filteredSoldiers {
+    return _allSoldiers.where((soldier) {
+      final name = soldier['name'].toString().toLowerCase();
+      return name.contains(_searchQuery.toLowerCase());
+    }).toList();
+  }
+
+  void _toggleParticipant(String soldierId) {
+    final List<String> updatedParticipants = [...widget.selectedParticipants];
+    final Map<String, String> updatedReasons = {...widget.soldierReason};
+
+    if (updatedParticipants.contains(soldierId)) {
+      updatedParticipants.remove(soldierId);
+      updatedReasons[soldierId] = 'Removed from conduct';
+    } else {
+      updatedParticipants.add(soldierId);
+      updatedReasons.remove(soldierId);
+    }
+
+    widget.onParticipantsChanged(updatedParticipants, updatedReasons);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          decoration: const InputDecoration(
+            labelText: 'Search Soldiers',
+            prefixIcon: Icon(Icons.search),
+          ),
+          onChanged: (value) {
+            setState(() {
+              _searchQuery = value;
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Select Participants',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: _filteredSoldiers.length,
+          itemBuilder: (context, index) {
+            final soldier = _filteredSoldiers[index];
+            final isSelected = widget.selectedParticipants.contains(soldier['id']);
+
+            return ListTile(
+              title: Text(soldier['name']),
+              subtitle: Text(soldier['rank']),
+              trailing: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: isSelected ? Colors.red : Colors.green,
+                ),
+                onPressed: () => _toggleParticipant(soldier['id']),
+                child: Text(
+                  isSelected ? 'REMOVE' : 'ADD',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+} 

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -5,7 +5,7 @@ class ParticipantSelector extends StatefulWidget {
   final List<String> selectedParticipants;
   final Map<String, String> soldierReason;
   final String? conductType;
-  final Function(List<String>, Map<String, String>) onParticipantsChanged;
+  final Function(List<String>, Map<String, String>, List<String>) onParticipantsChanged;
 
   const ParticipantSelector({
     super.key,
@@ -22,7 +22,7 @@ class ParticipantSelector extends StatefulWidget {
 class _ParticipantSelectorState extends State<ParticipantSelector> {
   List<Map<String, dynamic>> _allSoldiers = [];
   String _searchQuery = '';
-  bool _isInitialized = false;
+  List<String> _nonParticipants = [];
 
   @override
   void initState() {
@@ -38,22 +38,15 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
     
     setState(() {
       _allSoldiers = soldiers;
+      _updateNonParticipants();
     });
-
-    // Auto-select all participants only when the screen is first loaded
-    // and no participants are already selected
-    if (!_isInitialized && widget.selectedParticipants.isEmpty) {
-      final List<String> allSoldierIds = soldiers.map((s) => s['id'].toString()).toList();
-      widget.onParticipantsChanged(allSoldierIds, {});
-      _isInitialized = true;
-    }
   }
 
-  List<Map<String, dynamic>> get _filteredSoldiers {
-    return _allSoldiers.where((soldier) {
-      final name = soldier['name'].toString().toLowerCase();
-      return name.contains(_searchQuery.toLowerCase());
-    }).toList();
+  void _updateNonParticipants() {
+    _nonParticipants = _allSoldiers
+        .map((s) => s['id'].toString())
+        .where((id) => !widget.selectedParticipants.contains(id))
+        .toList();
   }
 
   void _toggleParticipant(String soldierId) {
@@ -68,7 +61,15 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
       updatedReasons.remove(soldierId);
     }
 
-    widget.onParticipantsChanged(updatedParticipants, updatedReasons);
+    _updateNonParticipants();
+    widget.onParticipantsChanged(updatedParticipants, updatedReasons, _nonParticipants);
+  }
+
+  List<Map<String, dynamic>> get _filteredSoldiers {
+    return _allSoldiers.where((soldier) {
+      final name = soldier['name'].toString().toLowerCase();
+      return name.contains(_searchQuery.toLowerCase());
+    }).toList();
   }
 
   @override
@@ -102,11 +103,11 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
               onPressed: () {
                 if (widget.selectedParticipants.length == _allSoldiers.length) {
                   // Deselect all
-                  widget.onParticipantsChanged([], {});
+                  widget.onParticipantsChanged([], {}, []);
                 } else {
                   // Select all
                   final allSoldierIds = _allSoldiers.map((s) => s['id'].toString()).toList();
-                  widget.onParticipantsChanged(allSoldierIds, {});
+                  widget.onParticipantsChanged(allSoldierIds, {}, []);
                 }
               },
               child: Text(

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -8,12 +8,12 @@ class ParticipantSelector extends StatefulWidget {
   final Function(List<String>, Map<String, String>) onParticipantsChanged;
 
   const ParticipantSelector({
-    Key? key,
+    super.key,
     required this.selectedParticipants,
     required this.soldierReason,
     required this.conductType,
     required this.onParticipantsChanged,
-  }) : super(key: key);
+  });
 
   @override
   State<ParticipantSelector> createState() => _ParticipantSelectorState();

--- a/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
+++ b/trooptrak_final_application/lib/features/conduct_tracker/presentation/widgets/participant_selector.dart
@@ -38,7 +38,14 @@ class _ParticipantSelectorState extends State<ParticipantSelector> {
     
     setState(() {
       _allSoldiers = soldiers;
-      _updateNonParticipants();
+      
+      // Auto-select all soldiers if this is a new conduct (i.e., selectedParticipants is empty)
+      if (widget.selectedParticipants.isEmpty) {
+        final allSoldierIds = soldiers.map((s) => s['id'].toString()).toList();
+        widget.onParticipantsChanged(allSoldierIds, {}, []);
+      } else {
+        _updateNonParticipants();
+      }
     });
   }
 

--- a/trooptrak_final_application/lib/features/detailed_view/presentation/pages/soldier_detailed_screen.dart
+++ b/trooptrak_final_application/lib/features/detailed_view/presentation/pages/soldier_detailed_screen.dart
@@ -20,6 +20,7 @@ class SoldierDetailedScreen extends StatefulWidget {
 class _SoldierDetailedScreenState extends State<SoldierDetailedScreen>
     with TickerProviderStateMixin {
   late TabController _tabController;
+  // ignore: unused_field
   bool _isLoading = true;
 
   @override

--- a/trooptrak_final_application/lib/features/nominal_roll/presentation/pages/edit_soldier_screen.dart
+++ b/trooptrak_final_application/lib/features/nominal_roll/presentation/pages/edit_soldier_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+// ignore: unused_import
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:trooptrak_final_application/features/nominal_roll/presentation/providers/user_detail_provider.dart';
 import 'package:trooptrak_final_application/features/nominal_roll/domain/entities/user.dart';
@@ -422,7 +423,7 @@ class _EditSoldierScreenState extends State<EditSoldierScreen> {
 
     return Container(
       decoration: BoxDecoration(
-        color: Color.fromARGB(255, 229, 229, 229),
+        color: const Color.fromARGB(255, 229, 229, 229),
         borderRadius: BorderRadius.circular(16.r),
         border: Border.all(
           color: Colors.deepPurple.withOpacity(0.3),
@@ -520,7 +521,7 @@ class _EditSoldierScreenState extends State<EditSoldierScreen> {
 
     return Container(
       decoration: BoxDecoration(
-        color: Color.fromARGB(255, 229, 229, 229),
+        color: const Color.fromARGB(255, 229, 229, 229),
         borderRadius: BorderRadius.circular(16.r),
         border: Border.all(
           color: Colors.deepPurple.withOpacity(0.3),
@@ -552,7 +553,7 @@ class _EditSoldierScreenState extends State<EditSoldierScreen> {
                   color: Colors.deepPurple,
                   size: 24.sp,
                 ),
-                dropdownColor: Color.fromARGB(255, 229, 229, 229),
+                dropdownColor: const Color.fromARGB(255, 229, 229, 229),
                 style: theme.textTheme.bodyMedium?.copyWith(
                   fontSize: 16.sp,
                   color: Colors.black87,
@@ -596,7 +597,7 @@ class _EditSoldierScreenState extends State<EditSoldierScreen> {
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: Color.fromARGB(255, 229, 229, 229),
+          color: const Color.fromARGB(255, 229, 229, 229),
           borderRadius: BorderRadius.circular(16.r),
           border: Border.all(
             color: Colors.deepPurple.withOpacity(0.3),

--- a/trooptrak_final_application/pubspec.lock
+++ b/trooptrak_final_application/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -193,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.19.0"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.69.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -256,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.7"
+  horizontal_date_picker_flutter:
+    dependency: "direct main"
+    description:
+      name: horizontal_date_picker_flutter
+      sha256: "2266e6547b7a487891c2cbe30537241bf5208a1685b2c3f1f10718eda1c65df3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   http:
     dependency: transitive
     description:
@@ -340,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "00f33b908655e606b86d2ade4710a231b802eec6f11e87e4ea3783fd72077a50"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.1"
   js:
     dependency: transitive
     description:

--- a/trooptrak_final_application/pubspec.yaml
+++ b/trooptrak_final_application/pubspec.yaml
@@ -42,13 +42,15 @@ dependencies:
   google_fonts: ^6.2.1
   auto_size_text: ^3.0.0
   animated_toggle_switch: ^0.7.0
-  intl: ^0.19.0
+  intl: ^0.20.1
   dartz: ^0.10.1
   mobile_scanner: ^4.0.1
   image_picker: ^1.1.2
   flutter_slidable: ^3.1.1
   recase: ^4.1.0
   google_nav_bar: ^5.0.7
+  fl_chart: ^0.69.2
+  horizontal_date_picker_flutter: ^0.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added the entirety of functionality from the old application. There are many UI changes left. As that is your domain I did not spend alot of time in there. 

Conduct feature Main ones (not exhaustive):
1. Make the top calendar days to actually point to current day. Now the current day is toward the right of the screen and one has to pull all the way to the right to see it. The days is auto selected as today, but as for seeing the selection in the top row horizontally scrolling calendar, one has to travel to it to see the current day is already selected.
2. The add_conduct_screen needs Major UI changes. To my knowledge I made sure most functionality have been copied over.
3. The conduct_details_screen needs a overhaul to look like the past one.
4. The current landing page for conducts: conducts_tracker_screen is not good looking. It misses the title and the date selection using the date picker is done when you click on the 'Select Date' text on the top left corner of the page. Need to change how it looks and how the datepicker looks as well.
5. The plus symbol in the page needs revamp
6.  Need to match the name of `conducts types` to the ones in the old app, and should align with the file `filter_participants_usecase.dart`

Status tab:
1. Change the look of the add_status_screen
2. Bring back the list for excuses


In both cases I have made it so the add_screen will be repurposed as the edit_screen. That will be most efficient. Do additional changes once there are made. I believe the `conduct tiles` could look much better after seeing what the new attendance tiles looks like